### PR TITLE
Change from ClimaCell v3 to Tomorrow.io v4 API

### DIFF
--- a/climacell.go
+++ b/climacell.go
@@ -60,7 +60,7 @@ var ccDescriptions = map[string]string{
 	"freezing_rain_heavy": "Heavy freezing rain",
 }
 
-const ccAPI = "https://api.climacell.co/v3/weather"
+const ccAPI = "https://api.tomorrow.io/v4/timelines"
 
 const ccUnits = "si"
 


### PR DESCRIPTION
This likely needs more than a change in the URL, but it’s a start

Fixes #24